### PR TITLE
Implement refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ s = Wsapi::Session.new("deadbeefdeadbeef")
 The constructor also accepts the following options:
   * `:workspace_id`, if not given, user's default workspace is used for queries
   * `:version`, WSAPI version, default is `3.0`
-  * `oauth2_refresh_token`, see: (using WSAPI with OAuth2)[https://github.com/flowdock/rally-wsapi#using-wsapi-with-oauth2]
+  * `oauth2`, see: (using WSAPI with OAuth2)[https://github.com/flowdock/rally-wsapi#using-wsapi-with-oauth2]
 
 ### Using WSAPI with OAuth2
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,15 @@ s = Wsapi::Session.new("deadbeefdeadbeef")
 The constructor also accepts the following options:
   * `:workspace_id`, if not given, user's default workspace is used for queries
   * `:version`, WSAPI version, default is `3.0`
+  * `oauth2_refresh_token`, see: (using WSAPI with OAuth2)[https://github.com/flowdock/rally-wsapi#using-wsapi-with-oauth2]
 
+### Using WSAPI with OAuth2
+
+Authenticating to WSAPI is also possible with OAuth2. Access token used in
+requests is given in place of the API token. Refresh token can be supplied with
+`Wsapi::Session#.setup_refresh_token(client_id, client_secret, refresh_token)`
+method. It takes optional block parameter, which is called every time the
+access token is refreshed.
 
 ## Method reference for Session
 
@@ -80,6 +88,13 @@ get_editors(project_id, opts = {})
 ```
 update_artifact(artifact_type, artifact_id, parameters)
 ```
+
+### Setup refresh token to be used with OAuth2
+```
+setup_refresh_token(client_id, client_secret, refresh_token, &block)
+```
+
+See (Using WSAPI with OAuth2)[https://github.com/flowdock/rally-wsapi#using-wsapi-with-oauth2] for more info.
 
 ## Result objects
 

--- a/lib/wsapi/session.rb
+++ b/lib/wsapi/session.rb
@@ -43,6 +43,15 @@ module Wsapi
       @conn = connection(session_id)
     end
 
+    def setup_refresh_token(client_id, client_secret, refresh_token, &block)
+      @oauth2_refresh_token = {
+        client_id: client_id,
+        client_secret: client_secret,
+        refresh_token: refresh_token,
+        refresh_token_updated: block
+      }
+    end
+
     def get_user_subscription
       response = wsapi_get(wsapi_resource_url("Subscription"))
       Mapper.get_object(response)
@@ -161,7 +170,7 @@ module Wsapi
 
       refresh_params = {
         grant_type: "refresh_token",
-        refresh_token: @oauth2_refresh_token[:token],
+        refresh_token: @oauth2_refresh_token[:refresh_token],
         client_id: @oauth2_refresh_token[:client_id],
         client_secret: @oauth2_refresh_token[:client_secret]
       }
@@ -172,6 +181,9 @@ module Wsapi
       end
 
       check_response_for_errors!(response)
+      if @oauth2_refresh_token[:refresh_token_updated]
+        @oauth2_refresh_token[:refresh_token_updated].call(MultiJson.load(response.body))
+      end
       response
     end
 

--- a/lib/wsapi/session.rb
+++ b/lib/wsapi/session.rb
@@ -151,7 +151,7 @@ module Wsapi
 
     def wsapi_request_with_refresh_token(method, url, opts = {})
       response = @conn.send(method, url, opts)
-      if @oauth2_refresh_token && response.status == 403
+      if @oauth2_refresh_token && response.status == 401
         refresh_token_response = refresh_token!
 
         access_token = MultiJson.load(refresh_token_response.body)["access_token"]

--- a/spec/fixtures/wsapi/authorization_error.html
+++ b/spec/fixtures/wsapi/authorization_error.html
@@ -1,0 +1,37 @@
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+        <title>Error 401 Full authentication is required to access this resource</title>
+    </head>
+    <body>
+        <h2>HTTP ERROR 401</h2>
+        <p>Problem accessing /slm/webservice/. Reason:
+
+            <pre>    Full authentication is required to access this resource</pre>
+        </p>
+        <hr />
+        <i>
+            <small>Powered by Jetty://</small>
+        </i>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+    </body>
+</html>

--- a/spec/fixtures/wsapi/authorization_error.json
+++ b/spec/fixtures/wsapi/authorization_error.json
@@ -1,0 +1,8 @@
+{
+  "OperationResult": {
+    "Errors": [
+      "Authorization error"
+    ],
+    "Warnings": []
+  }
+}

--- a/spec/fixtures/wsapi/authorization_error.json
+++ b/spec/fixtures/wsapi/authorization_error.json
@@ -1,8 +1,0 @@
-{
-  "OperationResult": {
-    "Errors": [
-      "Authorization error"
-    ],
-    "Warnings": []
-  }
-}

--- a/spec/fixtures/wsapi/refresh_token.json
+++ b/spec/fixtures/wsapi/refresh_token.json
@@ -1,0 +1,7 @@
+{
+  "id_token": "???",
+  "refresh_token": "new_refresh_token",
+  "expires_in": 15552000,
+  "token_type": "Bearer",
+  "access_token": "new_access_token"
+}

--- a/spec/lib/session_spec.rb
+++ b/spec/lib/session_spec.rb
@@ -182,6 +182,14 @@ describe Wsapi::Session do
     end
 
     context "without refresh_token" do
+      it "raises exception when response is 401" do
+        stub_request(:get, /.*/).to_return(status: 401)
+
+        expect {
+          @wsapi.get_user_subscription
+        }.to raise_error(Wsapi::AuthorizationError)
+      end
+
       it "raises exception when response is 403" do
         stub_request(:get, /.*/).to_return(status: 403)
 

--- a/spec/lib/session_spec.rb
+++ b/spec/lib/session_spec.rb
@@ -142,7 +142,7 @@ describe Wsapi::Session do
 
   describe "with errors" do
     context "with refresh_token" do
-      let(:authorization_error) { File.read(File.join("spec", "fixtures", "wsapi", "authorization_error.json")) }
+      let(:authorization_error) { File.read(File.join("spec", "fixtures", "wsapi", "authorization_error.html")) }
       let(:refresh_token) { File.read(File.join("spec", "fixtures", "wsapi", "refresh_token.json")) }
       let(:user_data) { File.read(File.join("spec", "fixtures", "wsapi", "user.json")) }
 

--- a/spec/lib/session_spec.rb
+++ b/spec/lib/session_spec.rb
@@ -149,7 +149,7 @@ describe Wsapi::Session do
       before :each do
         @failing_request = stub_request(:get, wsapi_url_regexp('/User/1'))
           .with(headers: {'Zsessionid' => "deadbeefdeadbeef"})
-          .to_return(status: 403, body: authorization_error)
+          .to_return(status: 401, body: authorization_error)
         @successful_request = stub_request(:get, wsapi_url_regexp('/User/1'))
           .with(headers: { "Zsessionid" => "new_access_token"})
           .to_return(status: 200, body: user_data)

--- a/spec/lib/session_spec.rb
+++ b/spec/lib/session_spec.rb
@@ -145,23 +145,39 @@ describe Wsapi::Session do
       let(:authorization_error) { File.read(File.join("spec", "fixtures", "wsapi", "authorization_error.json")) }
       let(:refresh_token) { File.read(File.join("spec", "fixtures", "wsapi", "refresh_token.json")) }
       let(:user_data) { File.read(File.join("spec", "fixtures", "wsapi", "user.json")) }
-      it "requests a new access token with refresh token" do
-        failing_request = stub_request(:get, wsapi_url_regexp('/User/1'))
+
+      before :each do
+        @failing_request = stub_request(:get, wsapi_url_regexp('/User/1'))
           .with(headers: {'Zsessionid' => "deadbeefdeadbeef"})
           .to_return(status: 403, body: authorization_error)
-        successful_request = stub_request(:get, wsapi_url_regexp('/User/1'))
+        @successful_request = stub_request(:get, wsapi_url_regexp('/User/1'))
           .with(headers: { "Zsessionid" => "new_access_token"})
           .to_return(status: 200, body: user_data)
-        refresh_token_request = stub_request(:post, Wsapi::AUTH_URL).to_return(status: 200, body: refresh_token)
+        @refresh_token_request = stub_request(:post, Wsapi::AUTH_URL).to_return(status: 200, body: refresh_token)
+      end
 
-        @wsapi = Wsapi::Session.new(@token, oauth2_refresh_token: {token: @refresh_token, client_id: "foobar", client_secret: "thisisasecret"})
+      it "requests a new access token with refresh token" do
+        @wsapi.setup_refresh_token("foobar", "thisisasecret", @refresh_token)
         user = @wsapi.get_user(1)
         expect(user.name).to eq("Antti Pitkanen")
         expect(user.email).to eq("apitkanen@rallydev.com")
 
-        expect(failing_request).to have_been_made
-        expect(refresh_token_request).to have_been_made
-        expect(successful_request).to have_been_made
+        expect(@failing_request).to have_been_made
+        expect(@refresh_token_request).to have_been_made
+        expect(@successful_request).to have_been_made
+      end
+
+      it "calls the block given in setup_refresh_token with new tokens" do
+        expect { |b|
+          @wsapi.setup_refresh_token("foobar", "thisisasecret", @refresh_token, &b)
+          @wsapi.get_user(1)
+        }.to yield_with_args({
+          "id_token"=>"???",
+          "refresh_token"=>"new_refresh_token",
+          "expires_in"=>15552000,
+          "token_type"=>"Bearer",
+          "access_token"=>"new_access_token"
+        })
       end
     end
 

--- a/spec/lib/session_spec.rb
+++ b/spec/lib/session_spec.rb
@@ -4,6 +4,7 @@ require 'uri'
 describe Wsapi::Session do
   before :all do
     @token = "deadbeefdeadbeef"
+    @refresh_token = "monkeymonkey"
   end
 
   before :each do
@@ -140,6 +141,40 @@ describe Wsapi::Session do
   end
 
   describe "with errors" do
+    context "with refresh_token" do
+      let(:authorization_error) { File.read(File.join("spec", "fixtures", "wsapi", "authorization_error.json")) }
+      let(:refresh_token) { File.read(File.join("spec", "fixtures", "wsapi", "refresh_token.json")) }
+      let(:user_data) { File.read(File.join("spec", "fixtures", "wsapi", "user.json")) }
+      it "requests a new access token with refresh token" do
+        failing_request = stub_request(:get, wsapi_url_regexp('/User/1'))
+          .with(headers: {'Zsessionid' => "deadbeefdeadbeef"})
+          .to_return(status: 403, body: authorization_error)
+        successful_request = stub_request(:get, wsapi_url_regexp('/User/1'))
+          .with(headers: { "Zsessionid" => "new_access_token"})
+          .to_return(status: 200, body: user_data)
+        refresh_token_request = stub_request(:post, Wsapi::AUTH_URL).to_return(status: 200, body: refresh_token)
+
+        @wsapi = Wsapi::Session.new(@token, oauth2_refresh_token: {token: @refresh_token, client_id: "foobar", client_secret: "thisisasecret"})
+        user = @wsapi.get_user(1)
+        expect(user.name).to eq("Antti Pitkanen")
+        expect(user.email).to eq("apitkanen@rallydev.com")
+
+        expect(failing_request).to have_been_made
+        expect(refresh_token_request).to have_been_made
+        expect(successful_request).to have_been_made
+      end
+    end
+
+    context "without refresh_token" do
+      it "raises exception when response is 403" do
+        stub_request(:get, /.*/).to_return(status: 403)
+
+        expect {
+          @wsapi.get_user_subscription
+        }.to raise_error(Wsapi::AuthorizationError)
+      end
+    end
+
     it "raises exception with query error" do
       @error_data = File.read(File.join("spec", "fixtures", "wsapi", "query_error.json"))
       stub_request(:get, /.*/).to_return(status: 200, body: @error_data)
@@ -168,14 +203,6 @@ describe Wsapi::Session do
 
     it "raises exception when response is 401" do
       stub_request(:get, /.*/).to_return(status: 401)
-
-      expect {
-        @wsapi.get_user_subscription
-      }.to raise_error(Wsapi::AuthorizationError)
-    end
-
-    it "raises exception when response is 403" do
-      stub_request(:get, /.*/).to_return(status: 403)
 
       expect {
         @wsapi.get_user_subscription


### PR DESCRIPTION
Add `setup_refresh_token` method to `Wsapi::Session`, and request for new access token when WSAPI returns 403.

API works as follows:

```ruby
wsapi = Wsapi::Session.new("oauth2_access_token")
wsapi.setup_refresh_token("client_id", "client_secret", "oauth2_refresh_token") do |new_tokens|
  # ... do something with new tokens, update database or something else
end
```

Also as a bonus, document that WSAPI can be used with OAuth2 tokens too.