### PR TITLE
Add get_subscription_by_subscription_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,14 @@ If the query_string is present, applies it to the request. Otherwise returns all
 get_user_subscription
 ```
 
-#### Get a subscription
+#### Get a subscription by object id
 ```
-get_project(subscription_id)
+get_subscription(object_id)
+```
+
+#### Get a subscription by subscription id
+```
+get_subscription_by_subscription_id(subscription_id)
 ```
 
 #### Get a project

--- a/lib/wsapi/models/subscription.rb
+++ b/lib/wsapi/models/subscription.rb
@@ -3,5 +3,9 @@ module Wsapi
     def subscription_id
       @raw_data["SubscriptionID"].to_s
     end
+
+    def obj_id
+      @raw_data["ObjectID"]
+    end
   end
 end

--- a/lib/wsapi/session.rb
+++ b/lib/wsapi/session.rb
@@ -63,6 +63,11 @@ module Wsapi
       Mapper.get_object(response)
     end
 
+    def get_subscription_by_subscription_id(subscription_id)
+      response = wsapi_get(wsapi_resource_url("Subscription"), query: "(SubscriptionId = #{subscription_id})", pagesize: 1)
+      (Mapper.get_objects(response) ||[]).first
+    end
+
     def get_projects(opts = {})
       fetch_with_pages(opts) do |page_query|
         wsapi_get(wsapi_resource_url("Project"), opts.merge(page_query))

--- a/spec/lib/session_spec.rb
+++ b/spec/lib/session_spec.rb
@@ -120,17 +120,26 @@ describe Wsapi::Session do
   describe "with subscriptions" do
     before :each do
       @subscription_data = File.read(File.join("spec", "fixtures", "wsapi", "subscription.json"))
-      stub_request(:get, wsapi_url_regexp('/Subscription/1')).to_return(status: 200, body: @subscription_data)
-      stub_request(:get, wsapi_url_regexp('/Subscription')).to_return(status: 200, body: @subscription_data)
+      @subscriptions_data = File.read(File.join("spec", "fixtures", "wsapi", "subscriptions.json"))
     end
 
     it "fetches user subscription" do
+      stub_request(:get, wsapi_url_regexp('/Subscription')).to_return(status: 200, body: @subscription_data)
       subscription = @wsapi.get_user_subscription
       expect(subscription.name).to eq("Rally Development")
     end
 
     it "fetches given subscription" do
+      stub_request(:get, wsapi_url_regexp('/Subscription/1')).to_return(status: 200, body: @subscription_data)
       subscription = @wsapi.get_subscription(1)
+      expect(subscription.name).to eq("Rally Development")
+    end
+
+    it "fetches given subscription by subscription id" do
+      stub_request(:get, wsapi_url_regexp('/Subscription')).with(
+        query: {"pagesize" => "1", "start" => "1", "fetch" => "true", "query" => "(SubscriptionId = 2)"}
+      ).to_return(status: 200, body: @subscriptions_data)
+      subscription = @wsapi.get_subscription_by_subscription_id(2)
       expect(subscription.name).to eq("Rally Development")
     end
   end


### PR DESCRIPTION
We have already `get_subscription(id)` but that uses object_id, so add a function that'll fetch subscription using the `subscriptionID` 

The naming of the function is a bit tautological, but I feel that `get_subscription_by_id` would be too similar to `get_subscription(id)`

Also adds getter for getting object_id from raw data.